### PR TITLE
EZStorage 2のDollyの挙動を修正

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation rfg.deobf("curse.maven:baubles-227083:2518667")
     implementation rfg.deobf("curse.maven:shadowfacts-forgelin-248453:2785465")
     implementation rfg.deobf("curse.maven:ae-additions-extra-cells-2-fork-493962:3814371")
+    implementation rfg.deobf("curse.maven:ez-storage2-245425:2530747")
 
     // Soft Dependencies
     implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.687"

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,9 +51,9 @@ apiPackage =
 accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
-usesMixins = false
+usesMixins = true
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
-mixinsPackage =
+mixinsPackage = mixins
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
 coreModClass = GTEMixinPlugin

--- a/src/main/java/gtexpert/GTEMixinLoader.java
+++ b/src/main/java/gtexpert/GTEMixinLoader.java
@@ -1,0 +1,15 @@
+package gtexpert;
+
+import com.google.common.collect.Lists;
+import zone.rong.mixinbooter.ILateMixinLoader;
+
+import java.util.List;
+
+public class GTEMixinLoader implements ILateMixinLoader {
+
+    @Override
+    public List<String> getMixinConfigs() {
+        return Lists.newArrayList("mixins.gtexpert.json");
+    }
+
+}

--- a/src/main/java/gtexpert/mixins/MixinItemDolly.java
+++ b/src/main/java/gtexpert/mixins/MixinItemDolly.java
@@ -1,0 +1,30 @@
+package gtexpert.mixins;
+
+import com.zerofall.ezstorage.item.EZItem;
+import com.zerofall.ezstorage.item.ItemDolly;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemDolly.class)
+public abstract class MixinItemDolly extends EZItem {
+
+    public MixinItemDolly(String name) {
+        super(name);
+    }
+
+    @Inject(method = "onItemUse", at = @At("HEAD"), remap = false, cancellable = true)
+    public void injectOnItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir) {
+        cir.setReturnValue(EnumActionResult.PASS);
+        cir.cancel();
+    }
+
+}

--- a/src/main/java/gtexpert/mixins/MixinItemDolly.java
+++ b/src/main/java/gtexpert/mixins/MixinItemDolly.java
@@ -2,17 +2,30 @@ package gtexpert.mixins;
 
 import com.zerofall.ezstorage.item.EZItem;
 import com.zerofall.ezstorage.item.ItemDolly;
+import com.zerofall.ezstorage.tileentity.TileEntityStorageCore;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockChest;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Objects;
 
 @Mixin(ItemDolly.class)
 public abstract class MixinItemDolly extends EZItem {
@@ -25,6 +38,126 @@ public abstract class MixinItemDolly extends EZItem {
     public void injectOnItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir) {
         cir.setReturnValue(EnumActionResult.PASS);
         cir.cancel();
+    }
+
+    @Override
+    public @NotNull ActionResult<ItemStack> onItemRightClick(@NotNull World world, @NotNull EntityPlayer player, @NotNull EnumHand hand) {
+        ItemStack heldItem = player.getHeldItem(hand);
+        if (world.isRemote) {
+            return new ActionResult<>(EnumActionResult.PASS, heldItem);
+        }
+
+        NBTTagCompound nbt = heldItem.getTagCompound();
+        RayTraceResult raytraceresult = this.rayTrace(world, player, false);
+        BlockPos pos = raytraceresult.getBlockPos();
+        if (nbt != null && nbt.getBoolean("isFull")) {
+            BlockPos placePos = pos.offset(raytraceresult.sideHit);
+            Block block = Block.getBlockFromName(nbt.getString("blockType"));
+            if (block == null || !world.getBlockState(placePos).getBlock().isReplaceable(world, placePos) || !block.canPlaceBlockAt(world, placePos)) {
+                return new ActionResult<>(EnumActionResult.FAIL, heldItem);
+            }
+
+            IBlockState state = block.getDefaultState();
+            if (block.equals(Blocks.CHEST)) {
+                state = state.withProperty(BlockChest.FACING, player.getHorizontalFacing().getOpposite());
+            }
+
+            world.setBlockState(placePos, state);
+            TileEntity targetTileEntity = world.getTileEntity(placePos);
+            if (targetTileEntity != null) {
+                NBTTagCompound stored = nbt.getCompoundTag("stored");
+                stored.setInteger("x", placePos.getX());
+                stored.setInteger("y", placePos.getY());
+                stored.setInteger("z", placePos.getZ());
+                targetTileEntity.readFromNBT(stored);
+            } else {
+                world.setBlockToAir(placePos);
+                return new ActionResult<>(EnumActionResult.FAIL, heldItem);
+            }
+
+            if (player.isCreative()) {
+                nbt.setBoolean("isFull", false);
+                nbt.removeTag("blockType");
+                nbt.removeTag("isChest");
+                nbt.removeTag("isStorageCore");
+                nbt.removeTag("stored");
+            } else {
+                ItemStack emptyDolly = heldItem.splitStack(1);
+                NBTTagCompound emptyDollyNBT = emptyDolly.getTagCompound();
+                if (emptyDollyNBT != null) {
+                    emptyDollyNBT.setBoolean("isFull", false);
+                    emptyDollyNBT.removeTag("blockType");
+                    emptyDollyNBT.removeTag("isChest");
+                    emptyDollyNBT.removeTag("isStorageCore");
+                    emptyDollyNBT.removeTag("stored");
+                }
+                emptyDolly.damageItem(1, player);
+
+                if (heldItem.isEmpty()) {
+                    return new ActionResult<>(EnumActionResult.SUCCESS, emptyDolly);
+                }
+
+                if (!player.addItemStackToInventory(emptyDolly)) {
+                    player.dropItem(emptyDolly, false);
+                }
+            }
+        } else {
+            if (!world.isBlockModifiable(player, pos)) {
+                return new ActionResult<>(EnumActionResult.FAIL, heldItem);
+            }
+
+            if (raytraceresult.typeOfHit != RayTraceResult.Type.BLOCK) {
+                return new ActionResult<>(EnumActionResult.PASS, heldItem);
+            }
+
+            IBlockState state = world.getBlockState(pos);
+            TileEntity tileEntity = world.getTileEntity(pos);
+            boolean isChest = tileEntity instanceof TileEntityChest;
+            boolean isStorageCore = tileEntity instanceof TileEntityStorageCore;
+            if (!(isChest || isStorageCore)) {
+                return new ActionResult<>(EnumActionResult.PASS, heldItem);
+            }
+
+            NBTTagCompound distTag = new NBTTagCompound();
+            NBTTagCompound storageData = tileEntity.writeToNBT(new NBTTagCompound());
+            distTag.setBoolean("isFull", true);
+            distTag.setString("blockType", Objects.requireNonNull(state.getBlock().getRegistryName()).toString());
+            distTag.setBoolean("isChest", isChest);
+            distTag.setBoolean("isStorageCore", isStorageCore);
+            distTag.setTag("stored", storageData);
+
+            if (isStorageCore) {
+                world.setBlockToAir(pos);
+                world.removeTileEntity(pos);
+            } else {
+                world.removeTileEntity(pos);
+                world.setBlockToAir(pos);
+            }
+
+            if (player.isCreative()) {
+                heldItem.setTagCompound(distTag);
+            } else {
+                ItemStack distItem = heldItem.splitStack(1);
+                distItem.setTagCompound(distTag);
+
+                if (heldItem.isEmpty()) {
+                    return new ActionResult<>(EnumActionResult.SUCCESS, distItem);
+                }
+
+                if (!player.addItemStackToInventory(distItem)) {
+                    player.dropItem(distItem, false);
+                }
+            }
+        }
+        return new ActionResult<>(EnumActionResult.SUCCESS, heldItem);
+    }
+
+    @Override
+    public int getItemStackLimit(ItemStack stack) {
+        NBTTagCompound nbt = stack.getTagCompound();
+        if (nbt != null && nbt.getBoolean("isFull"))
+            return 1;
+        return super.getItemStackLimit(stack);
     }
 
 }

--- a/src/main/resources/mixins.gtexpert.json
+++ b/src/main/resources/mixins.gtexpert.json
@@ -1,0 +1,17 @@
+{
+  "required": true,
+  "package": "gtexpert.mixins",
+  "refmap": "mixins.gtexpert.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "server": [
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "minVersion": "0.8"
+}

--- a/src/main/resources/mixins.gtexpert.json
+++ b/src/main/resources/mixins.gtexpert.json
@@ -5,6 +5,7 @@
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinItemDolly"
   ],
   "server": [
   ],


### PR DESCRIPTION
- 2つ以上スタックされているDollyにブロックを格納した際に、スタック全体にブロックを格納してしまう問題を修正
  - クリエイティブモードでは元の挙動を維持
- ブロックが格納されているDollyはスタック出来ないように変更
- 何らかの手段でブロックが格納されているDollyをスタックしても、設置時に1つだけ減るように修正
  - クリエイティブモードでは元の挙動を維持
- 通常設置できない場所にChestを設置できてしまう問題を修正
- Storage Coreの収納が不安定な問題を修正