### PR TITLE
Add BrokenSpawer resipe to SoulBinder

### DIFF
--- a/src/main/java/com/github/gtexpert/core/integration/eio/recipes/EIOItemsRecipe.java
+++ b/src/main/java/com/github/gtexpert/core/integration/eio/recipes/EIOItemsRecipe.java
@@ -29,13 +29,13 @@ public class EIOItemsRecipe {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(Items.PAPER)
                 .input("dyeBlack")
-                .circuitMeta(2)
+                .circuitMeta(4)
                 .outputs(Mods.EnderIO.getItem("item_material", 1, 77))
                 .duration(100).EUt(4).buildAndRegister();
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(Items.PAPER)
                 .fluidInputs(Materials.DyeBlack.getFluid(72))
-                .circuitMeta(2)
+                .circuitMeta(4)
                 .outputs(Mods.EnderIO.getItem("item_material", 1, 77))
                 .duration(100).EUt(4).buildAndRegister();
 

--- a/src/main/java/com/github/gtexpert/core/integration/eio/recipes/EIOSoulBinderRecipe.java
+++ b/src/main/java/com/github/gtexpert/core/integration/eio/recipes/EIOSoulBinderRecipe.java
@@ -59,6 +59,18 @@ public class EIOSoulBinderRecipe {
                     .output(ModObject.itemSoulVial.getItemNN())
                     .output(ModObject.itemSoulFilterBig.getItemNN())
                     .duration(1000).EUt(VA[LV]).buildAndRegister();
+
+            // SoulBinder - Broken Spawner
+            ItemStack spawnerStack = new ItemStack(ModObject.itemBrokenSpawner.getItemNN(), 1, 0);
+            spawnerStack.setTagCompound(tag);
+            EnderIORecipeMaps.SOUL_BINDER_RECIPES.recipeBuilder()
+                    .input(new GTRecipeItemInput(stack).setNBTMatchingCondition(NBTMatcher.RECURSIVE_EQUAL_TO,
+                            NBTCondition.create(NBTTagType.STRING, "entityId", name.toString())))
+                    .inputNBT(ModObject.itemBrokenSpawner.getItem(), NBTMatcher.ANY, NBTCondition.ANY)
+                    .fluidInputs(GTEUtility.getModFluid("xpjuice", 2240))
+                    .output(ModObject.itemSoulVial.getItemNN())
+                    .outputs(spawnerStack)
+                    .duration(1200).EUt(VA[MV]).buildAndRegister();
         }
     }
 


### PR DESCRIPTION
GTEのSoulBinderにBrokenSpawerの書き換えレシピを追加しました。
EIO側の使用エネルギーが多かったので、仮としてMVレシピにしてあります。

GTFO導入時にEIOのBlack PaperとGTFOのPaper Bagが回路重複していたので、EIO側を2から4に変更しました。