### PR TITLE
Add Void Fluid Pump

### DIFF
--- a/src/main/java/com/github/gtexpert/core/api/capability/impl/VoidFluidPumpLogic.java
+++ b/src/main/java/com/github/gtexpert/core/api/capability/impl/VoidFluidPumpLogic.java
@@ -1,0 +1,329 @@
+package com.github.gtexpert.core.api.capability.impl;
+
+import com.github.gtexpert.core.common.metatileentities.multi.MetaTileEntityVoidFluidPump;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
+import gregtech.common.ConfigHolder;
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityFluidDrill;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+import org.jetbrains.annotations.NotNull;
+
+public class VoidFluidPumpLogic {
+
+    public static final int MAX_PROGRESS = 20;
+
+    private int progressTime = 0;
+
+    private final MetaTileEntityVoidFluidPump metaTileEntity;
+
+    private boolean isActive;
+    private boolean isWorkingEnabled = true;
+    private boolean wasActiveAndNeedsUpdate;
+    private boolean isDone = false;
+    protected boolean isInventoryFull;
+
+    private boolean hasNotEnoughEnergy;
+
+    private Fluid veinFluid;
+
+    public VoidFluidPumpLogic(MetaTileEntityVoidFluidPump metaTileEntity) {
+        this.metaTileEntity = metaTileEntity;
+        this.veinFluid = null;
+    }
+
+    /**
+     * Performs the actual drilling
+     * Call this method every tick in update
+     */
+    public void performDrilling() {
+        if (metaTileEntity.getWorld().isRemote) return;
+
+        // if we have no fluid, try to get a new one
+        if (veinFluid == null)
+            if (!acquireNewFluid())
+                return; // stop if we still have no fluid
+
+        // drills that cannot work do nothing
+        if (!this.isWorkingEnabled)
+            return;
+
+        // check if drilling is possible
+        if (!checkCanDrain())
+            return;
+
+        // if the inventory is not full, drain energy etc. from the drill
+        // the storages have already been checked earlier
+        if (!isInventoryFull) {
+            // actually drain the energy
+            consumeEnergy(false);
+
+            // since energy is being consumed the rig is now active
+            if (!this.isActive)
+                setActive(true);
+        } else {
+            // the rig cannot drain, therefore it is inactive
+            if (this.isActive)
+                setActive(false);
+            return;
+        }
+
+        // increase progress
+        progressTime++;
+        if (progressTime % MAX_PROGRESS != 0)
+            return;
+        progressTime = 0;
+
+        int amount = getFluidToProduce();
+
+        if (metaTileEntity.fillTanks(new FluidStack(veinFluid, amount), true)) {
+            metaTileEntity.fillTanks(new FluidStack(veinFluid, amount), false);
+            depleteVein();
+        } else {
+            isInventoryFull = true;
+            setActive(false);
+            setWasActiveAndNeedsUpdate(true);
+        }
+    }
+
+    protected boolean consumeEnergy(boolean simulate) {
+        return metaTileEntity.drainEnergy(simulate);
+    }
+
+    private boolean acquireNewFluid() {
+        this.veinFluid = BedrockFluidVeinHandler.getFluidInChunk(metaTileEntity.getWorld(), getChunkX(), getChunkZ());
+        return this.veinFluid != null;
+    }
+
+    public Fluid getDrilledFluid() {
+        return veinFluid;
+    }
+
+    protected void depleteVein() {
+        BedrockFluidVeinHandler.depleteVein(metaTileEntity.getWorld(), getChunkX(), getChunkZ(), 0, true);
+    }
+
+    public int getFluidToProduce() {
+        int depletedYield = BedrockFluidVeinHandler.getDepletedFluidYield(metaTileEntity.getWorld(), getChunkX(),
+                getChunkZ());
+        int regularYield = BedrockFluidVeinHandler.getFluidYield(metaTileEntity.getWorld(), getChunkX(), getChunkZ());
+        int remainingOperations = BedrockFluidVeinHandler.getOperationsRemaining(metaTileEntity.getWorld(), getChunkX(),
+                getChunkZ());
+
+        int produced = Math.max(depletedYield,
+                regularYield * remainingOperations / BedrockFluidVeinHandler.MAXIMUM_VEIN_OPERATIONS);
+        produced *= metaTileEntity.getRigMultiplier();
+
+        return produced;
+    }
+
+    /**
+     *
+     * @return true if the rig is able to drain, else false
+     */
+    protected boolean checkCanDrain() {
+        if (!consumeEnergy(true)) {
+            if (progressTime >= 2) {
+                if (ConfigHolder.machines.recipeProgressLowEnergy)
+                    this.progressTime = 1;
+                else
+                    this.progressTime = Math.max(1, progressTime - 2);
+
+                hasNotEnoughEnergy = true;
+            }
+            return false;
+        }
+
+        if (this.hasNotEnoughEnergy &&
+                metaTileEntity.getEnergyInputPerSecond() > 19L * GTValues.VA[metaTileEntity.getEnergyTier()]) {
+            this.hasNotEnoughEnergy = false;
+        }
+
+        if (metaTileEntity.fillTanks(new FluidStack(veinFluid, getFluidToProduce()), true)) {
+            this.isInventoryFull = false;
+            return true;
+        }
+        this.isInventoryFull = true;
+
+        if (isActive()) {
+            setActive(false);
+            setWasActiveAndNeedsUpdate(true);
+        }
+        return false;
+    }
+
+    public int getChunkX() {
+        return Math.floorDiv(metaTileEntity.getPos().getX(), 16);
+    }
+
+    public int getChunkZ() {
+        return Math.floorDiv(metaTileEntity.getPos().getZ(), 16);
+    }
+
+    /**
+     *
+     * @return true if the rig is active
+     */
+    public boolean isActive() {
+        return this.isActive;
+    }
+
+    /**
+     *
+     * @param active the new state of the rig's activity: true to change to active, else false
+     */
+    public void setActive(boolean active) {
+        if (this.isActive != active) {
+            this.isActive = active;
+            this.metaTileEntity.markDirty();
+            if (metaTileEntity.getWorld() != null && !metaTileEntity.getWorld().isRemote) {
+                this.metaTileEntity.writeCustomData(GregtechDataCodes.WORKABLE_ACTIVE, buf -> buf.writeBoolean(active));
+            }
+        }
+    }
+
+    /**
+     *
+     * @param isWorkingEnabled the new state of the rig's ability to work: true to change to enabled, else false
+     */
+    public void setWorkingEnabled(boolean isWorkingEnabled) {
+        if (this.isWorkingEnabled != isWorkingEnabled) {
+            this.isWorkingEnabled = isWorkingEnabled;
+            metaTileEntity.markDirty();
+            if (metaTileEntity.getWorld() != null && !metaTileEntity.getWorld().isRemote) {
+                this.metaTileEntity.writeCustomData(GregtechDataCodes.WORKING_ENABLED,
+                        buf -> buf.writeBoolean(isWorkingEnabled));
+            }
+        }
+    }
+
+    /**
+     *
+     * @return whether working is enabled for the logic
+     */
+    public boolean isWorkingEnabled() {
+        return isWorkingEnabled;
+    }
+
+    /**
+     *
+     * @return whether the rig is currently working
+     */
+    public boolean isWorking() {
+        return isActive && !hasNotEnoughEnergy && isWorkingEnabled;
+    }
+
+    /**
+     *
+     * @return the current progress towards producing fluid of the rig
+     */
+    public int getProgressTime() {
+        return this.progressTime;
+    }
+
+    public double getProgressPercent() {
+        return getProgressTime() * 1.0 / MAX_PROGRESS;
+    }
+
+
+    /**
+     *
+     * @return whether the inventory is full
+     */
+    public boolean isInventoryFull() {
+        return this.isInventoryFull;
+    }
+
+    /**
+     * writes all needed values to NBT
+     * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeToNBT(NBTTagCompound)} method
+     */
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
+        data.setBoolean("isActive", this.isActive);
+        data.setBoolean("isWorkingEnabled", this.isWorkingEnabled);
+        data.setBoolean("wasActiveAndNeedsUpdate", this.wasActiveAndNeedsUpdate);
+        data.setBoolean("isDone", isDone);
+        data.setInteger("progressTime", progressTime);
+        data.setBoolean("isInventoryFull", isInventoryFull);
+        return data;
+    }
+
+    /**
+     * reads all needed values from NBT
+     * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#readFromNBT(NBTTagCompound)}
+     * method
+     */
+    public void readFromNBT(@NotNull NBTTagCompound data) {
+        this.isActive = data.getBoolean("isActive");
+        this.isWorkingEnabled = data.getBoolean("isWorkingEnabled");
+        this.wasActiveAndNeedsUpdate = data.getBoolean("wasActiveAndNeedsUpdate");
+        this.isDone = data.getBoolean("isDone");
+        this.progressTime = data.getInteger("progressTime");
+        this.isInventoryFull = data.getBoolean("isInventoryFull");
+    }
+
+    /**
+     * writes all needed values to InitialSyncData
+     * This MUST be called and returned in the MetaTileEntity's
+     * {@link MetaTileEntity#writeInitialSyncData(PacketBuffer)} method
+     */
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
+        buf.writeBoolean(this.isActive);
+        buf.writeBoolean(this.isWorkingEnabled);
+        buf.writeBoolean(this.wasActiveAndNeedsUpdate);
+        buf.writeInt(this.progressTime);
+        buf.writeBoolean(this.isInventoryFull);
+    }
+
+    /**
+     * reads all needed values from InitialSyncData
+     * This MUST be called and returned in the MetaTileEntity's
+     * {@link MetaTileEntity#receiveInitialSyncData(PacketBuffer)} method
+     */
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
+        setActive(buf.readBoolean());
+        setWorkingEnabled(buf.readBoolean());
+        setWasActiveAndNeedsUpdate(buf.readBoolean());
+        this.progressTime = buf.readInt();
+        this.isInventoryFull = buf.readBoolean();
+    }
+
+    /**
+     * reads all needed values from CustomData
+     * This MUST be called and returned in the MetaTileEntity's
+     * {@link MetaTileEntity#receiveCustomData(int, PacketBuffer)} method
+     */
+    public void receiveCustomData(int dataId, PacketBuffer buf) {
+        if (dataId == GregtechDataCodes.WORKABLE_ACTIVE) {
+            this.isActive = buf.readBoolean();
+            metaTileEntity.scheduleRenderUpdate();
+        } else if (dataId == GregtechDataCodes.WORKING_ENABLED) {
+            this.isWorkingEnabled = buf.readBoolean();
+            metaTileEntity.scheduleRenderUpdate();
+        }
+    }
+
+    /**
+     *
+     * @return whether the rig was active and needs an update
+     */
+    public boolean wasActiveAndNeedsUpdate() {
+        return this.wasActiveAndNeedsUpdate;
+    }
+
+    /**
+     * set whether the rig was active and needs an update
+     *
+     * @param wasActiveAndNeedsUpdate the state to set
+     */
+    public void setWasActiveAndNeedsUpdate(boolean wasActiveAndNeedsUpdate) {
+        this.wasActiveAndNeedsUpdate = wasActiveAndNeedsUpdate;
+    }
+}

--- a/src/main/java/com/github/gtexpert/core/common/GTEConfigHolder.java
+++ b/src/main/java/com/github/gtexpert/core/common/GTEConfigHolder.java
@@ -53,6 +53,20 @@ public class GTEConfigHolder {
                 "3. EIO: Capacitor Bank",
                 "Default: true" })
         public boolean addCreativeRecipe = true;
+
+        @Config.Comment({ "The base voltage of Void Fluid Pump",
+                "Minimum: 0 (ULV)",
+                "Maximum: 9 (UHV)",
+                "Default: 4 (EV)"})
+        @Config.RangeInt(min = 0, max = 9)
+        public int vfpBaseVoltage = 4;
+
+        @Config.Comment({ "The base of Production Rate of Void Fluid Pump",
+                "Total Production Multiplier = Base Production Rate * (Current Voltage - Base Voltage)",
+                "Minimum: 1",
+                "Default: 16"})
+        @Config.RangeInt(min = 1)
+        public int vfpBaseProductionRate = 16;
     }
 
     public static class GregtechOverride {

--- a/src/main/java/com/github/gtexpert/core/common/metatileentities/GTEMetaTileEntities.java
+++ b/src/main/java/com/github/gtexpert/core/common/metatileentities/GTEMetaTileEntities.java
@@ -25,6 +25,7 @@ public class GTEMetaTileEntities {
     public static MetaTileEntityAdvancedChemicalPlant ADVANCED_CHEMICAL_PLANT;
     public static MetaTileEntityLargeGasCollector LARGE_GAS_COLLECTOR;
     public static MetaTileEntityLargeTransformer LARGE_TRANSFORMER;
+    public static MetaTileEntityVoidFluidPump VOID_FLUID_PUMP;
 
     public static void init() {
         // Single Machine
@@ -45,6 +46,8 @@ public class GTEMetaTileEntities {
                         "large_gas_collector" : "advanced_gas_collector")));
         LARGE_TRANSFORMER = registerMetaTileEntity(12008,
                 new MetaTileEntityLargeTransformer(gteId("large_transformer")));
+        VOID_FLUID_PUMP = registerMetaTileEntity(12009,
+                new MetaTileEntityVoidFluidPump((gteId("void_fluid_pump"))));
     }
 
     public static void registerGTESimpleMetaTileEntity(GTESimpleMachineMetaTileEntity[] machines, int startId,

--- a/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
+++ b/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
@@ -8,6 +8,7 @@ import com.github.gtexpert.core.api.gui.GTEGuiTextures;
 import com.github.gtexpert.core.api.unification.material.GTEMaterials;
 
 import com.github.gtexpert.core.client.GTETextures;
+import com.github.gtexpert.core.common.GTEConfigHolder;
 import com.github.gtexpert.core.common.blocks.GTEBlockMetalCasing;
 import com.github.gtexpert.core.common.blocks.GTEMetaBlocks;
 
@@ -257,11 +258,11 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
     }
 
     public int getBaseTier() {
-        return GTValues.EV;
+        return GTEConfigHolder.gteFlag.vfpBaseVoltage;
     }
 
     public int getBaseMultiplier() {
-        return 16;
+        return GTEConfigHolder.gteFlag.vfpBaseProductionRate;
     }
 
 

--- a/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
+++ b/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
@@ -1,0 +1,403 @@
+package com.github.gtexpert.core.common.metatileentities.multi;
+
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Matrix4;
+import com.github.gtexpert.core.api.capability.impl.VoidFluidPumpLogic;
+import com.github.gtexpert.core.api.gui.GTEGuiTextures;
+import com.github.gtexpert.core.api.unification.material.GTEMaterials;
+
+import com.github.gtexpert.core.client.GTETextures;
+import com.github.gtexpert.core.common.blocks.GTEBlockMetalCasing;
+import com.github.gtexpert.core.common.blocks.GTEMetaBlocks;
+
+import com.google.common.collect.Lists;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.capability.IWorkable;
+import gregtech.api.capability.impl.EnergyContainerList;
+import gregtech.api.capability.impl.FluidDrillLogic;
+import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.resources.TextureArea;
+import gregtech.api.metatileentity.ITieredMetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.IProgressBarMultiblock;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
+import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
+
+import gregtech.api.pattern.BlockPattern;
+import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.pattern.PatternMatchContext;
+
+import gregtech.api.unification.material.Materials;
+
+import gregtech.api.util.GTTransferUtils;
+import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextComponentUtil;
+import gregtech.api.util.TextFormattingUtil;
+import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
+import gregtech.common.blocks.BlockSteamCasing;
+import gregtech.common.blocks.MetaBlocks;
+import gregtech.common.metatileentities.MetaTileEntities;
+
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityFluidDrill;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
+        implements IWorkable, IProgressBarMultiblock {
+
+    private final VoidFluidPumpLogic minerLogic;
+
+    protected IMultipleTankHandler inputFluidInventory;
+    protected IMultipleTankHandler outputFluidInventory;
+    protected IEnergyContainer energyContainer;
+
+    public MetaTileEntityVoidFluidPump(ResourceLocation metaTileEntityId) {
+        super(metaTileEntityId);
+        this.minerLogic = new VoidFluidPumpLogic(this);
+    }
+
+    @Override
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
+        return new MetaTileEntityVoidFluidPump(metaTileEntityId);
+    }
+
+    protected void initializeAbilities() {
+        this.inputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.IMPORT_FLUIDS));
+        this.outputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.EXPORT_FLUIDS));
+        this.energyContainer = new EnergyContainerList(getAbilities(MultiblockAbility.INPUT_ENERGY));
+    }
+
+    private void resetTileAbilities() {
+        this.inputFluidInventory = new FluidTankList(true);
+        this.outputFluidInventory = new FluidTankList(true);
+        this.energyContainer = new EnergyContainerList(Lists.newArrayList());
+    }
+
+    @Override
+    protected void formStructure(PatternMatchContext context) {
+        super.formStructure(context);
+        initializeAbilities();
+    }
+
+    @Override
+    public void invalidateStructure() {
+        super.invalidateStructure();
+        resetTileAbilities();
+    }
+
+    @Override
+    protected void updateFormedValid() {
+        this.minerLogic.performDrilling();
+        if (!getWorld().isRemote && this.minerLogic.wasActiveAndNeedsUpdate()) {
+            this.minerLogic.setWasActiveAndNeedsUpdate(false);
+            this.minerLogic.setActive(false);
+        }
+    }
+
+    @Override
+    protected @NotNull BlockPattern createStructurePattern() {
+        return FactoryBlockPattern.start()
+                .aisle("XXXXXXX", "****F**", "****F**", "****F**")
+                .aisle("XXXXHXX", "F*****F", "F*****F", "FFFFFFF")
+                .aisle("XXXXHXX", "*******", "*******", "****F**")
+                .aisle("XXXXHXX", "F*****F", "F*****F", "FFFFFFF")
+                .aisle("SXXXXXX", "****F**", "****F**", "****F**")
+                .where('S', selfPredicate())
+                .where('X', states(GTEMetaBlocks.GTE_METAL_CASING.getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setExactLimit(1))
+                        .or(autoAbilities(true, false)))
+                .where('F', frames(GTEMaterials.NM_HEA_NPs))
+                .where('H', abilities(MultiblockAbility.EXPORT_FLUIDS).setExactLimit(1)
+                        .or(states(GTEMetaBlocks.GTE_METAL_CASING.getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))))
+                .where('*', any())
+                .build();
+    }
+
+    @Override
+    protected boolean shouldShowVoidingModeButton() {
+        return false;
+    }
+
+    @Override
+    public boolean allowsExtendedFacing() {
+        return false;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public ICubeRenderer getBaseTexture(IMultiblockPart iMultiblockPart) {
+        return GTETextures.VOID_ORE_MINER_CASING;
+    }
+    @Override
+    protected @NotNull TextureArea getLogo() {
+        return GTEGuiTextures.GTE_LOGO_DARK;
+    }
+
+    @Override
+    protected @NotNull TextureArea getWarningLogo() {
+        return GTEGuiTextures.GTE_LOGO_BLINKING_YELLOW;
+    }
+
+    @Override
+    protected @NotNull TextureArea getErrorLogo() {
+        return GTEGuiTextures.GTE_LOGO_BLINKING_RED;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @NotNull
+    @Override
+    protected ICubeRenderer getFrontOverlay() {
+        return Textures.FLUID_VOIDING_ADVANCED;
+    }
+
+    @Override
+    protected void addDisplayText(List<ITextComponent> textList) {
+        MultiblockDisplayText.builder(textList, isStructureFormed())
+                .setWorkingStatus(minerLogic.isWorkingEnabled(), minerLogic.isActive())
+                .setWorkingStatusKeys(
+                        "gregtech.multiblock.idling",
+                        "gregtech.multiblock.work_paused",
+                        "gregtech.multiblock.miner.drilling")
+                .addEnergyUsageLine(energyContainer)
+                .addCustom(tl -> {
+                    if (isStructureFormed()) {
+                        if (minerLogic.getDrilledFluid() != null) {
+                            // Fluid name
+                            Fluid drilledFluid = minerLogic.getDrilledFluid();
+                            ITextComponent fluidInfo = TextComponentUtil
+                                    .setColor(GTUtility.getFluidTranslation(drilledFluid), TextFormatting.GREEN);
+                            tl.add(TextComponentUtil.translationWithColor(
+                                    TextFormatting.GRAY,
+                                    "gregtech.multiblock.fluid_rig.drilled_fluid",
+                                    fluidInfo));
+
+                            // Fluid amount
+                            ITextComponent amountInfo = TextComponentUtil.stringWithColor(
+                                    TextFormatting.BLUE,
+                                    TextFormattingUtil.formatNumbers(
+                                            minerLogic.getFluidToProduce() * 20L / FluidDrillLogic.MAX_PROGRESS) +
+                                            " L/s");
+                            tl.add(TextComponentUtil.translationWithColor(
+                                    TextFormatting.GRAY,
+                                    "gregtech.multiblock.fluid_rig.fluid_amount",
+                                    amountInfo));
+                        } else {
+                            ITextComponent noFluid = TextComponentUtil.translationWithColor(TextFormatting.RED,
+                                    "gregtech.multiblock.fluid_rig.no_fluid_in_area");
+                            tl.add(TextComponentUtil.translationWithColor(
+                                    TextFormatting.GRAY,
+                                    "gregtech.multiblock.fluid_rig.drilled_fluid",
+                                    noFluid));
+                        }
+                    }
+                })
+                .addWorkingStatusLine()
+                .addProgressLine(minerLogic.getProgressPercent());
+    }
+
+    @Override
+    protected void addWarningText(List<ITextComponent> textList) {
+        MultiblockDisplayText.builder(textList, isStructureFormed(), false)
+                .addLowPowerLine(isStructureFormed() && !drainEnergy(true))
+                .addCustom(tl -> {
+                    if (isStructureFormed() && minerLogic.isInventoryFull()) {
+                        tl.add(TextComponentUtil.translationWithColor(
+                                TextFormatting.YELLOW,
+                                "gregtech.machine.miner.invfull"));
+                    }
+                });
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip, boolean advanced) {
+        super.addInformation(stack,world, tooltip, advanced);
+        tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.1"));
+        tooltip.add(I18n.format("gregtech.machine.fluid_drilling_rig.description"));
+        tooltip.add(I18n.format("gregtech.machine.fluid_drilling_rig.depletion",
+                TextFormattingUtil.formatNumbers(0)));
+        tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.2", GTValues.VNF[getBaseTier()], getBaseMultiplier()));
+        tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.3"));
+    }
+
+    @Override
+    public void addToolUsages(ItemStack stack, @Nullable World world, List<String> tooltip, boolean advanced) {
+        tooltip.add(I18n.format("gregtech.tool_action.screwdriver.access_covers"));
+        tooltip.add(I18n.format("gregtech.tool_action.wrench.set_facing"));
+        super.addToolUsages(stack, world, tooltip, advanced);
+    }
+
+    public int getBaseTier() {
+        return GTValues.EV;
+    }
+
+    public int getBaseMultiplier() {
+        return 16;
+    }
+
+
+    public int getRigMultiplier() {
+        return Math.max(1, getBaseMultiplier() * (getEnergyTier() - getBaseTier()));
+    }
+
+    @Override
+    public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
+        super.renderMetaTileEntity(renderState, translation, pipeline);
+        this.getFrontOverlay().renderOrientedState(renderState, translation, pipeline, getFrontFacing(),
+                this.minerLogic.isActive(), this.minerLogic.isWorkingEnabled());
+    }
+
+    @Override
+    public boolean isWorkingEnabled() {
+        return this.minerLogic.isWorkingEnabled();
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean isActivationAllowed) {
+        this.minerLogic.setWorkingEnabled(isActivationAllowed);
+    }
+
+    public boolean fillTanks(FluidStack stack, boolean simulate) {
+        return GTTransferUtils.addFluidsToFluidHandler(outputFluidInventory, simulate,
+                Collections.singletonList(stack));
+    }
+
+    public int getEnergyTier() {
+        if (energyContainer == null) return getBaseTier();
+        return Math.max(getBaseTier(), GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage()));
+    }
+
+    public long getEnergyInputPerSecond() {
+        return energyContainer.getInputPerSec();
+    }
+
+    public boolean drainEnergy(boolean simulate) {
+        long energyToDrain = GTValues.VA[getEnergyTier()];
+        long resultEnergy = energyContainer.getEnergyStored() - energyToDrain;
+        if (resultEnergy >= 0L && resultEnergy <= energyContainer.getEnergyCapacity()) {
+            if (!simulate)
+                energyContainer.changeEnergy(-energyToDrain);
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound data) {
+        super.writeToNBT(data);
+        return this.minerLogic.writeToNBT(data);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound data) {
+        super.readFromNBT(data);
+        this.minerLogic.readFromNBT(data);
+    }
+
+    @Override
+    public void writeInitialSyncData(PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
+        this.minerLogic.writeInitialSyncData(buf);
+    }
+
+    @Override
+    public void receiveInitialSyncData(PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
+        this.minerLogic.receiveInitialSyncData(buf);
+    }
+
+    @Override
+    public void receiveCustomData(int dataId, PacketBuffer buf) {
+        super.receiveCustomData(dataId, buf);
+        this.minerLogic.receiveCustomData(dataId, buf);
+    }
+
+    @Override
+    public int getProgress() {
+        return minerLogic.getProgressTime();
+    }
+
+    @Override
+    public int getMaxProgress() {
+        return FluidDrillLogic.MAX_PROGRESS;
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        if (capability == GregtechTileCapabilities.CAPABILITY_WORKABLE)
+            return GregtechTileCapabilities.CAPABILITY_WORKABLE.cast(this);
+        if (capability == GregtechTileCapabilities.CAPABILITY_CONTROLLABLE)
+            return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
+        return super.getCapability(capability, side);
+    }
+
+
+    @Override
+    public boolean showProgressBar() {
+        return true;
+    }
+
+    @Override
+    public double getFillPercentage(int index) {
+        int numOperationsLeft = BedrockFluidVeinHandler.getOperationsRemaining(getWorld(), minerLogic.getChunkX(),
+                minerLogic.getChunkZ());
+        int maxOperations = BedrockFluidVeinHandler.MAXIMUM_VEIN_OPERATIONS;
+        return 1.0 * numOperationsLeft / maxOperations;
+    }
+
+    @Override
+    public TextureArea getProgressBarTexture(int index) {
+        return GuiTextures.PROGRESS_BAR_FLUID_RIG_DEPLETION;
+    }
+
+    @Override
+    public void addBarHoverText(List<ITextComponent> hoverList, int index) {
+        int numOperationsLeft = BedrockFluidVeinHandler.getOperationsRemaining(getWorld(), minerLogic.getChunkX(),
+                minerLogic.getChunkZ());
+        int maxOperations = BedrockFluidVeinHandler.MAXIMUM_VEIN_OPERATIONS;
+        int percentage = (int) Math.round(1.0 * numOperationsLeft / maxOperations * 100);
+        TextFormatting color = percentage > 40 ? TextFormatting.GREEN :
+                percentage > 10 ? TextFormatting.YELLOW : TextFormatting.RED;
+
+        if (numOperationsLeft == 0) {
+            hoverList.add(TextComponentUtil.translationWithColor(TextFormatting.RED,
+                    "gregtech.multiblock.fluid_rig.vein_depleted"));
+        } else {
+            ITextComponent veinInfo = TextComponentUtil.stringWithColor(color, percentage + "%");
+            hoverList.add(TextComponentUtil.translationWithColor(
+                    TextFormatting.GRAY,
+                    "gregtech.multiblock.fluid_rig.vein_depletion",
+                    veinInfo));
+        }
+    }
+}

--- a/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
+++ b/src/main/java/com/github/gtexpert/core/common/metatileentities/multi/MetaTileEntityVoidFluidPump.java
@@ -1,56 +1,7 @@
 package com.github.gtexpert.core.common.metatileentities.multi;
 
-import codechicken.lib.render.CCRenderState;
-import codechicken.lib.render.pipeline.IVertexOperation;
-import codechicken.lib.vec.Matrix4;
-import com.github.gtexpert.core.api.capability.impl.VoidFluidPumpLogic;
-import com.github.gtexpert.core.api.gui.GTEGuiTextures;
-import com.github.gtexpert.core.api.unification.material.GTEMaterials;
-
-import com.github.gtexpert.core.client.GTETextures;
-import com.github.gtexpert.core.common.GTEConfigHolder;
-import com.github.gtexpert.core.common.blocks.GTEBlockMetalCasing;
-import com.github.gtexpert.core.common.blocks.GTEMetaBlocks;
-
-import com.google.common.collect.Lists;
-
-import gregtech.api.GTValues;
-import gregtech.api.capability.GregtechTileCapabilities;
-import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.IWorkable;
-import gregtech.api.capability.impl.EnergyContainerList;
-import gregtech.api.capability.impl.FluidDrillLogic;
-import gregtech.api.capability.impl.FluidTankList;
-import gregtech.api.gui.GuiTextures;
-import gregtech.api.gui.resources.TextureArea;
-import gregtech.api.metatileentity.ITieredMetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.IMultiblockPart;
-import gregtech.api.metatileentity.multiblock.IProgressBarMultiblock;
-import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
-import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
-
-import gregtech.api.pattern.BlockPattern;
-import gregtech.api.pattern.FactoryBlockPattern;
-import gregtech.api.pattern.PatternMatchContext;
-
-import gregtech.api.unification.material.Materials;
-
-import gregtech.api.util.GTTransferUtils;
-import gregtech.api.util.GTUtility;
-import gregtech.api.util.TextComponentUtil;
-import gregtech.api.util.TextFormattingUtil;
-import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
-import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.texture.Textures;
-import gregtech.common.blocks.BlockSteamCasing;
-import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.MetaTileEntities;
-
-import gregtech.common.metatileentities.multi.electric.MetaTileEntityFluidDrill;
+import java.util.Collections;
+import java.util.List;
 
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -70,11 +21,50 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.List;
+import com.google.common.collect.Lists;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.capability.IWorkable;
+import gregtech.api.capability.impl.EnergyContainerList;
+import gregtech.api.capability.impl.FluidDrillLogic;
+import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.resources.TextureArea;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.IProgressBarMultiblock;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
+import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
+import gregtech.api.pattern.BlockPattern;
+import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.pattern.PatternMatchContext;
+import gregtech.api.util.GTTransferUtils;
+import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextComponentUtil;
+import gregtech.api.util.TextFormattingUtil;
+import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
+
+import com.github.gtexpert.core.api.capability.impl.VoidFluidPumpLogic;
+import com.github.gtexpert.core.api.gui.GTEGuiTextures;
+import com.github.gtexpert.core.api.unification.material.GTEMaterials;
+import com.github.gtexpert.core.client.GTETextures;
+import com.github.gtexpert.core.common.GTEConfigHolder;
+import com.github.gtexpert.core.common.blocks.GTEBlockMetalCasing;
+import com.github.gtexpert.core.common.blocks.GTEMetaBlocks;
+
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Matrix4;
 
 public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
-        implements IWorkable, IProgressBarMultiblock {
+                                         implements IWorkable, IProgressBarMultiblock {
 
     private final VoidFluidPumpLogic minerLogic;
 
@@ -134,12 +124,15 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
                 .aisle("XXXXHXX", "F*****F", "F*****F", "FFFFFFF")
                 .aisle("SXXXXXX", "****F**", "****F**", "****F**")
                 .where('S', selfPredicate())
-                .where('X', states(GTEMetaBlocks.GTE_METAL_CASING.getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setExactLimit(1))
-                        .or(autoAbilities(true, false)))
+                .where('X',
+                        states(GTEMetaBlocks.GTE_METAL_CASING
+                                .getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))
+                                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setExactLimit(1))
+                                        .or(autoAbilities(true, false)))
                 .where('F', frames(GTEMaterials.NM_HEA_NPs))
                 .where('H', abilities(MultiblockAbility.EXPORT_FLUIDS).setExactLimit(1)
-                        .or(states(GTEMetaBlocks.GTE_METAL_CASING.getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))))
+                        .or(states(GTEMetaBlocks.GTE_METAL_CASING
+                                .getState(GTEBlockMetalCasing.MetalCasingType.VOID_ORE_MINER))))
                 .where('*', any())
                 .build();
     }
@@ -159,6 +152,7 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
     public ICubeRenderer getBaseTexture(IMultiblockPart iMultiblockPart) {
         return GTETextures.VOID_ORE_MINER_CASING;
     }
+
     @Override
     protected @NotNull TextureArea getLogo() {
         return GTEGuiTextures.GTE_LOGO_DARK;
@@ -240,13 +234,15 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip, boolean advanced) {
-        super.addInformation(stack,world, tooltip, advanced);
+    public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip,
+                               boolean advanced) {
+        super.addInformation(stack, world, tooltip, advanced);
         tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.fluid_drilling_rig.description"));
         tooltip.add(I18n.format("gregtech.machine.fluid_drilling_rig.depletion",
                 TextFormattingUtil.formatNumbers(0)));
-        tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.2", GTValues.VNF[getBaseTier()], getBaseMultiplier()));
+        tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.2", GTValues.VNF[getBaseTier()],
+                getBaseMultiplier()));
         tooltip.add(I18n.format("gtexpert.machine.void_fluid_pump.tooltip.3"));
     }
 
@@ -264,7 +260,6 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
     public int getBaseMultiplier() {
         return GTEConfigHolder.gteFlag.vfpBaseProductionRate;
     }
-
 
     public int getRigMultiplier() {
         return Math.max(1, getBaseMultiplier() * (getEnergyTier() - getBaseTier()));
@@ -311,7 +306,6 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
         }
         return false;
     }
-
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
@@ -361,7 +355,6 @@ public class MetaTileEntityVoidFluidPump extends MultiblockWithDisplayBase
             return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
         return super.getCapability(capability, side);
     }
-
 
     @Override
     public boolean showProgressBar() {

--- a/src/main/java/com/github/gtexpert/core/loaders/recipe/GTERecipe.java
+++ b/src/main/java/com/github/gtexpert/core/loaders/recipe/GTERecipe.java
@@ -866,6 +866,40 @@ public class GTERecipe {
                 'P', new UnificationEntry(plate, Materials.Palladium),
                 'C', new UnificationEntry(circuit, MarkerMaterials.Tier.EV),
                 'H', MetaTileEntities.HULL[EV].getStackForm());
+
+        // Void Fluid Pump
+        AssemblyLineRecipeBuilder builderVFP = RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
+                .input(MetaTileEntities.ADVANCED_FLUID_DRILLING_RIG)
+                .fluidInputs(Materials.SolderingAlloy.getFluid(18432))
+                .output(GTEMetaTileEntities.VOID_FLUID_PUMP);
+        if (GTEValues.isModLoadedDEDA()) {
+            builderVFP.inputs(Mods.DraconicEvolution.getItem("awakened_core", 4, 0))
+                    .input(MetaItems.ELECTRIC_MOTOR_UV, 4)
+                    .input(MetaItems.ELECTRIC_PUMP_UV, 4)
+                    .input(MetaItems.CONVEYOR_MODULE_UV, 4)
+                    .input(MetaItems.ELECTRIC_PISTON_UV, 4)
+                    .input(MetaItems.ROBOT_ARM_UV, 4)
+                    .input(MetaItems.EMITTER_UV, 4)
+                    .input(MetaItems.SENSOR_UV, 4)
+                    .duration(600).EUt(VA[UV])
+                    .stationResearch(
+                    b -> b.researchStack(MetaTileEntities.ADVANCED_FLUID_DRILLING_RIG.getStackForm()).CWUt(96).EUt(VA[UV]));
+        } else {
+            builderVFP.input(circuit, MarkerMaterials.Tier.ZPM, 4)
+                    .input(MetaItems.ELECTRIC_MOTOR_ZPM, 4)
+                    .input(MetaItems.ELECTRIC_PUMP_ZPM, 4)
+                    .input(MetaItems.CONVEYOR_MODULE_ZPM, 4)
+                    .input(MetaItems.ELECTRIC_PISTON_ZPM, 4)
+                    .input(MetaItems.ROBOT_ARM_ZPM, 4)
+                    .input(MetaItems.EMITTER_ZPM, 4)
+                    .input(MetaItems.SENSOR_ZPM, 4)
+                    .duration(600).EUt(VA[ZPM])
+                    .stationResearch(
+                    b -> b.researchStack(MetaTileEntities.ADVANCED_FLUID_DRILLING_RIG.getStackForm()).CWUt(64).EUt(VA[ZPM]));
+        }
+        builderVFP.input(MetaItems.FLUID_FILTER)
+                .input(gear, Materials.NaquadahAlloy, 4)
+                .buildAndRegister();
     }
 
     private static void tools() {

--- a/src/main/resources/assets/gtexpert/lang/en_us.lang
+++ b/src/main/resources/assets/gtexpert/lang/en_us.lang
@@ -31,6 +31,10 @@ gtexpert.machine.large_transformer.name=Large Adjustable Transformer
 gtexpert.machine.large_transformer.tooltip=The one that was in the old Gregicality
 gtexpert.machine.large_transformer.tooltip.1=Simplified version of active transformers
 gtexpert.machine.large_transformer.tooltip.2=§dAuthor:§f @MrKono
+gtexpert.machine.void_fluid_pump.name=Void Fluid Pump
+gtexpert.machine.void_fluid_pump.tooltip.1=Infinite Oil Deposit
+gtexpert.machine.void_fluid_pump.tooltip.2=For every voltage tier above §b%s§7, Production Multiplier is §e%dx§7.
+gtexpert.machine.void_fluid_pump.tooltip.3=§dAuthor:§f @MrKono
 
 # singleblock
 # Auto Chisel

--- a/src/main/resources/assets/gtexpert/lang/ja_jp.lang
+++ b/src/main/resources/assets/gtexpert/lang/ja_jp.lang
@@ -31,6 +31,10 @@ gtexpert.machine.large_transformer.name=大型可変変圧器
 gtexpert.machine.large_transformer.tooltip=昔のGregicalityには居たやつ
 gtexpert.machine.large_transformer.tooltip.1=大型変圧器の簡易版
 gtexpert.machine.large_transformer.tooltip.2=§d作者:§f @MrKono
+gtexpert.machine.void_fluid_pump.name=亜空間型液体ポンプ
+gtexpert.machine.void_fluid_pump.tooltip.1=無限の油田
+gtexpert.machine.void_fluid_pump.tooltip.2=使用電圧が§b%s§7よりも高い場合、電圧Tier毎に生産量が§e%d倍§7になる。
+gtexpert.machine.void_fluid_pump.tooltip.3=§d作者:§f @MrKono
 
 # singleblock
 # Auto Chisel


### PR DESCRIPTION
岩盤下の液脈を枯渇させないVoid Fluid Pumpを追加
---
**Void Fluid Pump**
- 動作のベースはFluid Drilling Rig (OCの意味なし)
- Fluid Drilling Rigと異なり、液脈の枯渇はさせない
- 基本電圧未満では動作しない
- Energy Hatchを1つに制限
- レシピはVOMと同じに設定
---
**仕様**
- 基本電圧はcfgの`vfpBaseVoltage`で設定 (デフォルトはEV)
- 生産量 = `液脈ごとの基本生産量 x 生産倍率`
- 生産倍率 = `vfpBaseProductionRate (cfg) x (動作電圧 - 基本電圧)` (動作電圧 - 基本電圧 < 1ならば生産倍率は1) 
- 0除算エラーが発生したため、`FluidDrillLogic`の代わりに`VoidFluidPumpLogic`を実装
